### PR TITLE
remove NI from groups on individual page vote

### DIFF
--- a/application/controllers/Votes.php
+++ b/application/controllers/Votes.php
@@ -450,6 +450,9 @@
 
       // Votes - députés
       $data['deputes'] = $this->votes_model->get_vote_deputes($data['vote']['voteNumero'], $legislature);
+      $data['groupes'] = array_filter($data['groupes'], function($groupe) {
+          return $groupe['libelleAbrev'] !== 'NI';
+        });
 
       // OTHER VOTES
       if ($num > 1) {


### PR DESCRIPTION
J'ai enlevé le groupe NI de l'array . Il n'apparait plus dans la section "La position des groupes" ni dans le tableau en bas de la page dans l'onglet "Groupes", par contre NI est toujours disponible pour chaque député dans l'onglet "Deputés"