### PR TITLE
feat: add random selection from latest 15 explanations

### DIFF
--- a/application/controllers/Home.php
+++ b/application/controllers/Home.php
@@ -82,7 +82,7 @@
       */
 
       // Get explications
-      $data['explications'] = $this->votes_model->get_explications_last();
+      $data['explications'] = $this->votes_model->get_random_explications_last();
 
       //Get votes (cached)
       if(!in_array($_SERVER['REMOTE_ADDR'], localhost())){

--- a/application/models/Votes_model.php
+++ b/application/models/Votes_model.php
@@ -768,4 +768,35 @@
       return $this->db->get('explications_mp e', 3)->result_array();
     }
 
+    public function get_random_explications_last(): array
+    {
+        $sql = "SELECT 
+            e.*, 
+            d.nameFirst, 
+            d.nameLast, 
+            d.legislature AS legislature_last, 
+            d.libelleAbrev, 
+            d.couleurAssociee, 
+            d.dptSlug, 
+            d.nameUrl, 
+            v.vote, 
+            vd.title,
+            SUBSTR(e.mpId, 3) AS idImage,
+            CASE WHEN e.voteNumero < 0 THEN CONCAT('c', ABS(e.voteNumero)) ELSE e.voteNumero END AS voteNumeroFormatted,
+            CASE WHEN v.vote = 1 THEN 'pour' WHEN v.vote = -1 THEN 'contre' WHEN v.vote = 0 THEN 'abstention' ELSE NULL END AS voteLabel
+        FROM (
+            SELECT *
+            FROM explications_mp
+            WHERE state = 1
+            ORDER BY created_at DESC
+            LIMIT 15
+        ) AS e
+        LEFT JOIN deputes_last d ON e.mpId = d.mpId
+        JOIN votes_datan vd ON vd.legislature = e.legislature AND vd.voteNumero = e.voteNumero
+        LEFT JOIN votes_scores v ON v.legislature = e.legislature AND v.voteNumero = e.voteNumero AND v.mpId = e.mpId
+        ORDER BY RAND()
+        LIMIT 3";
+        
+        return $this->db->query($sql)->result_array();
+    }
   }


### PR DESCRIPTION
J'ai fait en sorte de mettre à jour la mise en avant des 3 dernières explications sur la homepage, afin de récupérer, non pas les 3 dernières, mais les 15 dernières explications tout en randomisant dessus et en limitant ensuite à 3.
Ça permet d'avoir un panel plus varié d'explications si par exemple un député en rédige une dizaine à la suite.

J'ai laissé en place la requête d'origine get_explications_last(). Et j'en ai créé une nouvelle get_random_explications_last().
C'était compliqué d'utiliser le query builder à cause de la sous-requête, donc je l'ai faite en SQL natif.